### PR TITLE
add authorization in import api

### DIFF
--- a/src/api/apiFetch/types.ts
+++ b/src/api/apiFetch/types.ts
@@ -2,7 +2,7 @@ export interface IApiHeaders {
   [key: string]: string;
 }
 
-type TypeMethod = 'POST' | 'GET' | 'DELETE';
+type TypeMethod = 'POST' | 'GET' | 'DELETE'|'PUT';
 
 export interface IApiFetch {
   method: TypeMethod;

--- a/src/api/importCar.ts
+++ b/src/api/importCar.ts
@@ -1,6 +1,6 @@
 import { apiFetch } from './apiFetch/apiFetch';
 
-export const fetchCars = (url: string) => {
+export const fetchImage = (url: string) => {
   return apiFetch({
     method: 'PUT',
     url,

--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import Typography from "@mui/material/Typography";
-import Box from "@mui/material/Box";
+import React from 'react';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
 import axios from 'axios';
 
 type CSVFileImportProps = {
@@ -24,27 +24,27 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
   };
 
   const uploadFile = async () => {
-    console.log("uploadFile to", url);
     if (!file) {
       console.log('File doesnt exist');
       return;
     }
-    // Get the presigned URL
+
     const response = await axios({
-      method: "GET",
+      method: 'GET',
       url,
       params: {
-        name: encodeURIComponent(file.name),
+        name: encodeURIComponent(file && file.name),
+      },
+      headers: {
+        Authorization: `Basic ${localStorage.getItem("authorization_token")}`,
       },
     });
-    console.log("File to upload: ", file.name);
-    console.log("Uploading to: ", response.data);
     const result = await fetch(response.data, {
-      method: "PUT",
+      method: 'PUT',
       body: file,
     });
-    console.log("Result: ", result);
-    setFile("");
+    console.log('Result: ', result);
+    setFile(undefined);
   };
   return (
     <Box>


### PR DESCRIPTION
FE-PR-https://github.com/DeepanshuGargEpam/shop-react-redux-cloudfront/pull/3

BE-PR-https://github.com/DeepanshuGargEpam/shop-backend/pull/5
Functionality implemented:
1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
3 - Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
5 - Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from localStorage
A localstorage item authorization_token should be set to receive 200 response.